### PR TITLE
request raw history

### DIFF
--- a/jupyter-repl.el
+++ b/jupyter-repl.el
@@ -1681,7 +1681,7 @@ Return the buffer switched to."
       (jupyter-sent
        (jupyter-history-request
         :n jupyter-repl-history-maximum-length
-        :raw nil
+        :raw t
         :unique t
         :handlers '(not "status"))))
     (erase-buffer)


### PR DESCRIPTION
If raw is nil then with SageMath kernels the history we're getting is `Integer(1) + Integer(2)` if `1+2` was issued as a command before, i.e. SageMath does some heavy processing of inputs.